### PR TITLE
fix(exec): properly stop goroutines

### DIFF
--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"CLI2UI/pkg/executor"
 	"encoding/json"
+
 	"github.com/labstack/gommon/log"
 	"github.com/yuyz0112/sunmao-ui-go-binding/pkg/arco"
 	"github.com/yuyz0112/sunmao-ui-go-binding/pkg/runtime"
@@ -56,14 +57,11 @@ func (u *UI) buildUI() {
 		_ = json.Unmarshal(b, &command)
 
 		go func() {
-			for {
-				select {
-				case s := <-stateCh:
-					err := eState.SetState(s, &connId)
-					if err != nil {
-						log.Error(err)
-					}
-					break
+			for !e.State.Done {
+				s := <-stateCh
+				err := eState.SetState(s, &connId)
+				if err != nil {
+					log.Error(err)
 				}
 			}
 		}()


### PR DESCRIPTION
There used to be a bug that goroutines for executing the commands will not exit properly. Instead, once STOP is signaled, the goroutines will keep running which result in hanging goroutines and the following effect:

https://github.com/webzard-io/CLI2UI/assets/44930252/6008fc11-9882-4673-ad5b-1ddf683acf75

After the fix:

https://github.com/webzard-io/CLI2UI/assets/44930252/96cecf91-2779-405c-a3be-8e152e0c4b45

