### PR TITLE
fix(config): proposed a workaround for the missing option when checked

### DIFF
--- a/pkg/config/form.go
+++ b/pkg/config/form.go
@@ -13,8 +13,10 @@ type Form struct {
 }
 
 type OptionValue struct {
-	Value any
-	Long  bool
+	Value    any
+	Long     bool
+	Enabled  bool
+	Required bool
 }
 
 func (c CLI) Script(f Form) string {
@@ -24,7 +26,7 @@ func (c CLI) Script(f Form) string {
 func parseScript(f *Form, script string, optionDelim string, explicitBool bool) string {
 	for _, k := range orderedKeys(f.Flags) {
 		v := f.Flags[k]
-		if v.Value == nil {
+		if !v.Enabled {
 			continue
 		}
 
@@ -48,7 +50,7 @@ func parseScript(f *Form, script string, optionDelim string, explicitBool bool) 
 
 	for _, k := range orderedKeys(f.Args) {
 		v := f.Args[k]
-		if v.Value == nil {
+		if !v.Enabled {
 			continue
 		}
 		script = fmt.Sprintf("%s %s", script, v.Value)
@@ -95,16 +97,21 @@ func parseForm(c *Command, f *Form) {
 	f.Args = args
 	f.Subcommands = subcommands
 
+	// TODO(xinxi.guo): type system has to be enhanced to make use of `Option.Default`, this is a workaround for now
 	for _, f := range c.Flags {
 		flags[f.Name] = &OptionValue{
-			Value: nil,
-			Long:  f.Long,
+			Long:     f.Long,
+			Value:    fmt.Sprintf("<%s>", f.Name),
+			Required: f.Required,
+			Enabled:  f.Required,
 		}
 	}
 
 	for _, a := range c.Args {
 		args[a.Name] = &OptionValue{
-			Value: nil,
+			Value:    fmt.Sprintf("<%s>", a.Name),
+			Required: a.Required,
+			Enabled:  a.Required,
 		}
 	}
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -60,7 +60,7 @@ type Option struct {
 	Long        bool       `json:"long,omitempty" yaml:"long,omitempty"` // if true, the flag will be specified in the form of `--flag` instead of `-flag`
 	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool       `json:"required,omitempty" yaml:"required,omitempty"`
-	Default     string     `json:"default,omitempty" yaml:"default,omitempty"`
+	Default     any        `json:"default,omitempty" yaml:"default,omitempty"`
 	Options     []string   `json:"options,omitempty" yaml:"options,omitempty"` // only required when Type=enum
 }
 

--- a/pkg/ui/events.go
+++ b/pkg/ui/events.go
@@ -23,14 +23,14 @@ type session struct {
 func (u UI) GetOrCreateSession(connId int) *session {
 	s, ok := sessions[connId]
 	if !ok {
-		f := toStruct[config.Form](u.fTpl)
+		f := u.fTpl.Clone()
 		stopCh := make(chan struct{})
 		stateCh := make(chan *executor.ExecuteState)
 		hbCh := make(chan struct{})
 		exec := executor.NewExecutor(stateCh, stopCh)
 
 		s = &session{
-			f:       &f,
+			f:       f,
 			exec:    &exec,
 			stateCh: stateCh,
 			stopCh:  stopCh,
@@ -68,7 +68,7 @@ func (u UI) registerEvents() {
 		p := toStruct[UpdateSubcommandParams[int]](m.Params)
 		form := p.Path.traverseForm(s.f)
 		form.Choice = p.Tabs[p.SubcommandIndex].Title
-		clearForm(form.Subcommands[form.Choice])
+		form.Subcommands[form.Choice].Clear()
 		return nil
 	})
 
@@ -162,7 +162,8 @@ func (u UI) registerEvents() {
 		s := u.GetOrCreateSession(connId)
 		p := toStruct[UpdateCheckedOptionsParams[[]string]](m.Params)
 		f := p.Path.traverseForm(s.f)
-		updateCheckedOptions(f, p.CheckedValues)
+		updateCheckedOptions(&f.Flags, p.CheckedValues)
+		updateCheckedOptions(&f.Args, p.CheckedValues)
 		return nil
 	})
 }

--- a/pkg/ui/events.go
+++ b/pkg/ui/events.go
@@ -47,6 +47,11 @@ type UpdateSubcommandParams[T int | string] struct {
 	Tabs            []TabProperties
 }
 
+type UpdateCheckedOptionsParams[T []string | string] struct {
+	Path          Path
+	CheckedValues T
+}
+
 type UpdateOptionValueParams struct {
 	Path       Path
 	OptionName string
@@ -63,7 +68,7 @@ func (u UI) registerEvents() {
 		p := toStruct[UpdateSubcommandParams[int]](m.Params)
 		form := p.Path.traverseForm(s.f)
 		form.Choice = p.Tabs[p.SubcommandIndex].Title
-		clearForm(form)
+		clearForm(form.Subcommands[form.Choice])
 		return nil
 	})
 
@@ -151,5 +156,13 @@ func (u UI) registerEvents() {
 		s := u.cli.Script(*sess.f)
 		sess.exec.State.Stdout = fmt.Sprintf("Command to be run:\r\n$ %s", s)
 		return execState.SetState(sess.exec.State, &connId)
+	})
+
+	u.r.Handle("UpdateCheckedOptions", func(m *runtime.Message, connId int) error {
+		s := u.GetOrCreateSession(connId)
+		p := toStruct[UpdateCheckedOptionsParams[[]string]](m.Params)
+		f := p.Path.traverseForm(s.f)
+		updateCheckedOptions(f, p.CheckedValues)
+		return nil
 	})
 }

--- a/pkg/ui/page.go
+++ b/pkg/ui/page.go
@@ -236,7 +236,20 @@ func (u UI) optionsInputForm(p Path, c config.Command) sunmao.BaseComponentBuild
 		Style("content", `
 		display: flex;
 		align-items: flex-end;
-		`)
+		`).
+		Event([]sunmao.EventHandler{
+			{
+				Type:        "onChange",
+				ComponentId: "$utils",
+				Method: sunmao.EventMethod{
+					Name: "binding/v1/UpdateCheckedOptions",
+					Parameters: UpdateCheckedOptionsParams[string]{
+						Path:          p,
+						CheckedValues: fmt.Sprintf("{{ %s.checkedValues }}", p.optionsCheckboxId()),
+					},
+				},
+			},
+		})
 
 	cbWrapper := u.arco.NewStack().
 		Properties(structToMap(StackProperties{

--- a/pkg/ui/utils.go
+++ b/pkg/ui/utils.go
@@ -86,38 +86,8 @@ func (p Path) traverseForm(f *config.Form) *config.Form {
 	return form
 }
 
-func clearForm(f *config.Form) {
-	for k := range f.Args {
-		f.Args[k].Value = fmt.Sprintf("<%s>", k)
-		f.Args[k].Enabled = f.Args[k].Required
-	}
-
-	for k := range f.Flags {
-		f.Flags[k].Value = fmt.Sprintf("<%s>", k)
-		f.Flags[k].Enabled = f.Flags[k].Required
-	}
-
-	for k := range f.Subcommands {
-		clearForm(f.Subcommands[k])
-	}
-}
-
-func updateCheckedOptions(f *config.Form, checked []string) {
-	for k, v := range f.Flags {
-		found := false
-		for _, cv := range checked {
-			if k == cv {
-				v.Enabled = true
-				found = true
-				break
-			}
-		}
-		if !found {
-			v.Enabled = false
-		}
-	}
-
-	for k, v := range f.Args {
+func updateCheckedOptions(v *map[string]*config.OptionValue, checked []string) {
+	for k, v := range *v {
 		found := false
 		for _, cv := range checked {
 			if k == cv {

--- a/pkg/ui/utils.go
+++ b/pkg/ui/utils.go
@@ -88,14 +88,46 @@ func (p Path) traverseForm(f *config.Form) *config.Form {
 
 func clearForm(f *config.Form) {
 	for k := range f.Args {
-		f.Args[k].Value = nil
+		f.Args[k].Value = fmt.Sprintf("<%s>", k)
+		f.Args[k].Enabled = f.Args[k].Required
 	}
 
 	for k := range f.Flags {
-		f.Flags[k].Value = nil
+		f.Flags[k].Value = fmt.Sprintf("<%s>", k)
+		f.Flags[k].Enabled = f.Flags[k].Required
 	}
 
 	for k := range f.Subcommands {
 		clearForm(f.Subcommands[k])
+	}
+}
+
+func updateCheckedOptions(f *config.Form, checked []string) {
+	for k, v := range f.Flags {
+		found := false
+		for _, cv := range checked {
+			if k == cv {
+				v.Enabled = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			v.Enabled = false
+		}
+	}
+
+	for k, v := range f.Args {
+		found := false
+		for _, cv := range checked {
+			if k == cv {
+				v.Enabled = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			v.Enabled = false
+		}
 	}
 }

--- a/test/config/form_test.go
+++ b/test/config/form_test.go
@@ -1,21 +1,32 @@
 package config_test
 
 import (
+	"CLI2UI/pkg/config"
 	"testing"
 )
 
 func TestScriptGeneration(t *testing.T) {
 	f := docker.Form()
 
-	f.Flags["config"].Value = "this-config.yaml"
-	f.Flags["config"].Long = true
+	f.Flags["config"] = &config.OptionValue{
+		Value:   "this-config.yaml",
+		Long:    true,
+		Enabled: true,
+	}
 
-	f.Flags["log-level"].Value = "info"
-	f.Flags["log-level"].Long = true
+	f.Flags["log-level"] = &config.OptionValue{
+		Value:   "info",
+		Long:    true,
+		Enabled: true,
+	}
+
 	f.Choice = "volume"
 
 	f.Subcommands["volume"].Choice = "create"
-	f.Subcommands["volume"].Subcommands["create"].Args["name"].Value = "new-volume"
+	f.Subcommands["volume"].Subcommands["create"].Args["name"] = &config.OptionValue{
+		Value:   "new-volume",
+		Enabled: true,
+	}
 
 	s := docker.Script(f)
 


### PR DESCRIPTION
Since the type system is not complete for now (`reflection` may needed in the future), `Option.Default` or `reflect.Zero()` cannot be inserted to the `config.Form`easily, thus a workaround is proposed.

Scripts will be rendered:

<img width="1920" alt="Screenshot 2023-07-11 at 6 06 12 PM (2)" src="https://github.com/webzard-io/CLI2UI/assets/44930252/f67d9d5c-da86-4b2e-adba-3e3759fd3dbf">

Fallback:

1. If `Option.Default != nil` then take its value
2. Otherwise fallback to `<Option.Name>`

